### PR TITLE
Update internal Print variable to a pointer

### DIFF
--- a/src/LibPrintf.cpp
+++ b/src/LibPrintf.cpp
@@ -12,16 +12,16 @@
 // modifying the original source file
 #include "../extras/printf/printf.c"
 
-static Print& print_instance = Serial;
+static Print* print_instance = &Serial;
 
 void printf_init(Print& PrintClass)
 {
-	print_instance = PrintClass;
+	print_instance = &PrintClass;
 }
 
 // If you use the default printf() implementation, this function will route the output
 // to the Serial class
 extern "C" __attribute__((weak)) void _putchar(char character)
 {
-	print_instance.print(character);
+	print_instance->print(character);
 }


### PR DESCRIPTION
I didn't realize you couldn't retarget a reference variable after it was initialized, so now Print is a pointer.

Resolves #19