### PR TITLE
Add library.json / v1.2.11

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,0 +1,21 @@
+{
+  "name": "LibPrintf",
+  "version": "1.2.11",
+  "description": "This library provides support for printf() and other printf-like functions with full format-string support. Default output is to Serial, but can be customized.",
+  "keywords": "printf, debugging",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/embeddedartistry/arduino-printf.git"
+  },
+  "license": "MIT",
+  "headers": "LibPrintf.h",
+  "frameworks": "arduino",
+  "platforms": "*",
+  "export": {
+    "include": [
+      "examples",
+      "src",
+      "extras/printf"
+    ]
+  }
+}


### PR DESCRIPTION
This is what we export now:

```
├── LICENSE
├── README.md
├── examples
│   ├── default_to_serial
│   │   └── default_to_serial.ino
│   ├── override_putchar
│   │   └── override_putchar.ino
│   └── specify_print_class
│       └── specify_print_class.ino
├── extras
│   └── printf
│       ├── printf.c
│       └── printf.h
├── library.json
├── library.properties
└── src
    ├── LibPrintf.cpp
    └── LibPrintf.h

7 directories, 11 files
```

